### PR TITLE
2️⃣ Multiple Accounts!

### DIFF
--- a/app/(routes)/accounts/[id]/AccountDashboard.tsx
+++ b/app/(routes)/accounts/[id]/AccountDashboard.tsx
@@ -10,6 +10,7 @@ import { selectCustomer } from "@/lib/features/customers/customerSlice";
 import { TransactionBreakdownChart } from "./TransactionBreakdownChart";
 import { MatIcon } from "@/app/components/icons/MatIcon";
 import { useAuth } from "@/app/guards/AuthContext";
+import { EditAccountNameDialog } from "./EditNameDialog";
 
 type AccountDashboardProps = { account: any };
 
@@ -21,6 +22,10 @@ export function AccountDashboard({ account }: AccountDashboardProps) {
 
   function openTransferMoneyDialog(): void {
     dispatch(dialogsAction.openTransferMoney());
+  }
+
+  function openEditDialog(): void {
+    dispatch(dialogsAction.openEditAccount());
   }
 
   if (!customer || !account) {
@@ -36,10 +41,10 @@ export function AccountDashboard({ account }: AccountDashboardProps) {
               <span className="capitalize">
                 {customer.first_name} {customer.last_name}
               </span>{" "}
-              &mdash; {account.name}{" "}
+              &mdash; <span className="capitalize">{account.name}</span>
             </div>
             {isLoggedIn && (
-              <button className="icon ghost">
+              <button onClick={openEditDialog} className="icon ghost">
                 <MatIcon icon="edit-outline" />
               </button>
             )}
@@ -61,6 +66,7 @@ export function AccountDashboard({ account }: AccountDashboardProps) {
       </Card>
       <RecentTransactions account={account} />
       {dialogs.transferMoney && <TransferMoneyDialog />}
+      {dialogs.editAccount && <EditAccountNameDialog />}
     </div>
   );
 }

--- a/app/(routes)/accounts/[id]/AccountDashboard.tsx
+++ b/app/(routes)/accounts/[id]/AccountDashboard.tsx
@@ -8,6 +8,8 @@ import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { dialogsAction } from "@/lib/features/dialogs/dialogsSlice";
 import { selectCustomer } from "@/lib/features/customers/customerSlice";
 import { TransactionBreakdownChart } from "./TransactionBreakdownChart";
+import { MatIcon } from "@/app/components/icons/MatIcon";
+import { useAuth } from "@/app/guards/AuthContext";
 
 type AccountDashboardProps = { account: any };
 
@@ -15,6 +17,7 @@ export function AccountDashboard({ account }: AccountDashboardProps) {
   const dispatch = useAppDispatch();
   const customer = useAppSelector(selectCustomer);
   const dialogs = useAppSelector((state) => state.dialogs);
+  const { isLoggedIn } = useAuth();
 
   function openTransferMoneyDialog(): void {
     dispatch(dialogsAction.openTransferMoney());
@@ -28,11 +31,18 @@ export function AccountDashboard({ account }: AccountDashboardProps) {
     <div className="flex flex-col gap-4">
       <Card>
         <div className="flex flex-col gap-2 text-center py-2">
-          <div className="text-xl">
-            <span className="capitalize">
-              {customer.first_name} {customer.last_name}
-            </span>{" "}
-            &mdash; {account.name}
+          <div className="flex items-center justify-center gap-1 text-xl">
+            <div>
+              <span className="capitalize">
+                {customer.first_name} {customer.last_name}
+              </span>{" "}
+              &mdash; {account.name}{" "}
+            </div>
+            {isLoggedIn && (
+              <button className="icon ghost">
+                <MatIcon icon="edit-outline" />
+              </button>
+            )}
           </div>
           <span className="text-3xl font-extrabold">{formatCurrency(account.balance)}</span>
           <div className="flex justify-center">

--- a/app/(routes)/accounts/[id]/EditNameDialog.tsx
+++ b/app/(routes)/accounts/[id]/EditNameDialog.tsx
@@ -1,0 +1,77 @@
+import { Dialog } from "@/app/components/dialog/Dialog";
+import { MatIcon } from "@/app/components/icons/MatIcon";
+import { useSnackbar } from "@/app/components/snackbar/snackbar-context";
+import { PATCH } from "@/app/utils/http-client";
+import { fetchAccount, selectAccount } from "@/lib/features/accounts/accountsSlice";
+import { dialogsAction } from "@/lib/features/dialogs/dialogsSlice";
+import { useAppDispatch, useAppSelector } from "@/lib/hooks";
+import { ChangeEvent, useState } from "react";
+
+export function EditAccountNameDialog() {
+  const account = useAppSelector(selectAccount);
+  const [formData, setFormData] = useState({ name: account?.name || "" });
+  const { showSnackbar } = useSnackbar();
+  const dispatch = useAppDispatch();
+
+  function close(event: any): void {
+    event.preventDefault();
+    dispatch(dialogsAction.closeEditAccount());
+  }
+
+  function handleChange(event: ChangeEvent<HTMLInputElement>): void {
+    const { name, value } = event.target;
+    setFormData({ ...formData, [name]: value });
+  }
+
+  async function submit(event: any): Promise<void> {
+    event.preventDefault();
+
+    if (!account) return;
+
+    try {
+      const response = await PATCH(`/accounts/${account?.id}`, { ...formData });
+      const data = await response.json();
+
+      if (response.ok) {
+        showSnackbar("Successfully updated account information");
+        dispatch(fetchAccount(account.id));
+        close(event);
+      } else {
+        showSnackbar(data.message);
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  return (
+    <Dialog>
+      <header>
+        <MatIcon icon="edit-outline" />
+        <h1>Edit Account</h1>
+      </header>
+      <form className="flex flex-col gap-4" onSubmit={submit}>
+        <div className="form-field">
+          <label htmlFor="name">Account Name</label>
+          <input
+            id="name"
+            name="name"
+            type="text"
+            autoFocus
+            className="capitalize"
+            placeholder="Account Name"
+            defaultValue={account?.name ?? ""}
+            required
+            onChange={handleChange}
+          />
+        </div>
+        <footer>
+          <button onClick={close} className="common ghost">
+            Cancel
+          </button>
+          <input type="submit" className="common ghost" value="Save" />
+        </footer>
+      </form>
+    </Dialog>
+  );
+}

--- a/app/(routes)/banks/[id]/CustomersTable.tsx
+++ b/app/(routes)/banks/[id]/CustomersTable.tsx
@@ -14,6 +14,7 @@ import { ThunkStatus } from "@/lib/thunk";
 import { TransferMoneyDialog } from "./dialogs/TransferMoneyDialog";
 import { ViewCustomerDialog } from "./dialogs/ViewCustomerDialog";
 import { formatCurrency } from "@/app/utils/formatters";
+import { accountsAction } from "@/lib/features/accounts/accountsSlice";
 
 export function CustomersTable() {
   const dispatch = useAppDispatch();
@@ -36,6 +37,7 @@ export function CustomersTable() {
   }
 
   function openTransferMoneyDialog(customer: any): void {
+    dispatch(accountsAction.setCurrentAccount(null));
     dispatch(customerAction.setCustomer(customer));
     dispatch(dialogsAction.openTransferMoney());
   }

--- a/app/(routes)/customer/accounts/[id]/page.tsx
+++ b/app/(routes)/customer/accounts/[id]/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { AccountDashboard } from "@/app/(routes)/accounts/[id]/AccountDashboard";
+import { CustomerGuard } from "@/app/guards/CustomerGuard";
+import { fetchAccount, selectAccount } from "@/lib/features/accounts/accountsSlice";
+import { appBarActions } from "@/lib/features/app-bar/appBarSlice";
+import { dialogsAction } from "@/lib/features/dialogs/dialogsSlice";
+import { useAppDispatch, useAppSelector } from "@/lib/hooks";
+import { useParams } from "next/navigation";
+import { useEffect } from "react";
+
+export default function CustomerAccountPage() {
+  const { id } = useParams();
+  const dispatch = useAppDispatch();
+  const account = useAppSelector(selectAccount);
+
+  useEffect(() => {
+    dispatch(fetchAccount(id as string));
+    dispatch(appBarActions.displayGoBack());
+    dispatch(dialogsAction.closeViewCustomer());
+
+    return () => {
+      dispatch(appBarActions.displayDefault());
+    };
+  }, [dispatch, id]);
+
+  if (id && !account) {
+    return <>Loading...</>;
+  }
+
+  return (
+    <CustomerGuard>
+      <AccountDashboard account={account} />
+    </CustomerGuard>
+  );
+}

--- a/app/(routes)/customer/dashboard.tsx
+++ b/app/(routes)/customer/dashboard.tsx
@@ -1,0 +1,61 @@
+import { Card } from "@/app/components/card/Card";
+import { formatCurrency } from "@/app/utils/formatters";
+import { selectCustomer } from "@/lib/features/customers/customerSlice";
+import { useAppSelector } from "@/lib/hooks";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { AccountDashboard } from "../accounts/[id]/AccountDashboard";
+
+export function CustomerDashboard() {
+  const customer = useAppSelector(selectCustomer);
+  const [networth, setNetworth] = useState(0);
+
+  useEffect(() => {
+    if (!customer) return;
+
+    setNetworth(() => {
+      return customer.accounts.reduce((previous, value) => previous + value.balance, 0);
+    });
+  }, [customer]);
+
+  if (customer && customer.accounts.length === 2) {
+    return <AccountDashboard account={customer.accounts[0]} />;
+  }
+
+  return (
+    <article className="flex flex-col gap-4">
+      <h1 className="text-2xl">
+        Welcome Back, <span className="capitalize">{customer?.first_name}</span>
+      </h1>
+      <Card>
+        <header className="text-center flex flex-col gap-1">
+          <h1 className="font-normal">Your Net Worth</h1>
+          <span className="text-4xl font-bold">{formatCurrency(networth)}</span>
+        </header>
+      </Card>
+      <div className="flex flex-col gap-2">
+        <h2 className="font-bold">Banking</h2>
+        <div>
+          <div className="grid grid-cols-2 border border-outline rounded-t-xl px-3 py-1 bg-gray-200 font-bold">
+            <div className="">Account</div>
+            <div className="text-right">Balance</div>
+          </div>
+          {customer?.accounts.map((account: any) => {
+            return (
+              <Link
+                href={`/customer/accounts/${account.id}`}
+                key={account.id}
+                className="grid grid-cols-2 border border-outline border-t-0 last:rounded-b-xl px-3 py-2 bg-white duration-300 transition-colors ease-in hover:bg-slate-100 cursor-pointer text-inherit hover:text-inherit no-underline"
+              >
+                <div className="">{account.name}</div>
+                <div className="text-right font-bold">
+                  {formatCurrency(account.balance)}&nbsp;&nbsp;&rsaquo;
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/app/(routes)/customer/dashboard.tsx
+++ b/app/(routes)/customer/dashboard.tsx
@@ -18,7 +18,7 @@ export function CustomerDashboard() {
     });
   }, [customer]);
 
-  if (customer && customer.accounts.length === 2) {
+  if (customer && customer.accounts.length === 1) {
     return <AccountDashboard account={customer.accounts[0]} />;
   }
 

--- a/app/(routes)/customer/page.tsx
+++ b/app/(routes)/customer/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useEffect } from "react";
-import { AccountDashboard } from "../accounts/[id]/AccountDashboard";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { fetchAccount, selectAccount } from "@/lib/features/accounts/accountsSlice";
 import { selectCustomer } from "@/lib/features/customers/customerSlice";
 import { CustomerGuard } from "@/app/guards/CustomerGuard";
+import { CustomerDashboard } from "./dashboard";
 
 export default function CustomerPage() {
   const dispatch = useAppDispatch();
@@ -26,5 +26,5 @@ export default function CustomerPage() {
     );
   }
 
-  return <AccountDashboard account={account}></AccountDashboard>;
+  return <CustomerDashboard />;
 }

--- a/lib/features/accounts/accountsSlice.ts
+++ b/lib/features/accounts/accountsSlice.ts
@@ -18,7 +18,11 @@ const accountsSlice = createSlice({
       status: ThunkStatus.Idle,
     },
   },
-  reducers: {},
+  reducers: {
+    setCurrentAccount(state, action) {
+      return { ...state, current: action.payload };
+    },
+  },
   extraReducers(builder) {
     builder
       .addCase(fetchAccount.pending, (state, _) => {

--- a/lib/features/dialogs/dialogsSlice.ts
+++ b/lib/features/dialogs/dialogsSlice.ts
@@ -10,6 +10,7 @@ const dialogsSlice = createSlice({
     deleteBank: false,
     viewCustomer: false,
     transferMoney: false,
+    editAccount: false,
   },
   reducers: {
     openCreateBankDialog(state) {
@@ -95,6 +96,12 @@ const dialogsSlice = createSlice({
         ...state,
         viewCustomer: false,
       };
+    },
+    openEditAccount(state) {
+      return { ...state, editAccount: true };
+    },
+    closeEditAccount(state) {
+      return { ...state, editAccount: false };
     },
   },
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "fun-banking-nextjs",
-  "version": "1.0.0",
+  "name": "fun-banking",
+  "version": "1.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
# 🏅 Multiple Account Support
 
This release allows you to create 2 accounts per customer. This feature is useful if you want to separate certain transactions.

The most common use-case for this would be for a "savings" account without all of the interest logic that we hope to bring in as a professional feature.

<img width="855" alt="Screenshot 2024-03-02 at 12 09 27 PM" src="https://github.com/bytebury/fun-banking/assets/104793781/029f9372-9480-49c5-b5ff-6e843b9097dc">

With that being said, the **Customer Dashboard** has some updates to support this (as seen in the screenshot above). Customers will only see this view if they have more than one account.

At this moment, you will be unable to close any accounts and only **Employees** can update the name of the account &mdash; which defaults to Checkings#2.

Thank you to everyone who provided feedback to us requested this feature. As always, if you see any issues please report them to bytebury@gmail.com
